### PR TITLE
Fix for Laravel >5.3 

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,11 +22,11 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->mergeConfigFrom($this->getConfigPath(), 'ipboard');
 
-        $this->app['ipboard'] = $this->app->share(function($app){
+        $this->app->singleton('ipboard', function($app){
             return new Ipboard();
         });
 
-        $this->app['command.ipboard.test'] = $this->app->share(
+        $this->app->singleton('command.ipboard.test', 
             function ($app) {
                 return new Console\TestCommand($app['ipboard']);
             }


### PR DESCRIPTION
Fixes the biggest issue preventing running in Laravel 5.3 -- there seems to still be errors if the code fails to get a successful api result, but the code at least runs. 