### PR TITLE
Bugfixes that allow the project to work on Laravel versions up to current.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "files": [
             "src/helpers.php"
         ]
-    }
+    },
 	"extra": {
 		"laravel": {
 			"providers": [

--- a/composer.json
+++ b/composer.json
@@ -21,4 +21,14 @@
             "src/helpers.php"
         ]
     }
+	"extra": {
+		"laravel": {
+			"providers": [
+				"Alawrence\\Ipboard\\ServiceProvider"
+			],
+			"aliases": {
+				"IpBoard": "Alawrence\\Ipboard\\Facade"
+			}
+		}
+	}
 }

--- a/config/ipboard.php
+++ b/config/ipboard.php
@@ -7,7 +7,7 @@
  */
 
 return [
-    "api_url" => "http://my.website.com/api/",
-    "api_key" => "YOUR_API_KEY_SHOULD_BE_PLACED_HERE",
-    "api_reference_name" => "SOME_REFERENCE",
+    'api_url'            => 'http://my.website.com/api/',
+    'api_key'            => 'YOUR_API_KEY_SHOULD_BE_PLACED_HERE',
+    'api_reference_name' => 'SOME_REFERENCE',
 ];

--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,19 @@ Require this package with composer:
 composer require alawrence/laravel-ipboard
 ```
 
-After updating composer, add this package's ServiceProvider to the providers array in config/app.php
+###  Laravel 5.5:
+
+In order to set the required variables for your instance of IPBoard, you must first publish the configuration files:
+
+```
+php artisan vendor:publish
+```
+
+Then, edit your API key and IP.Board URL into config/ipboard.php
 
 ### < Laravel 5.4:
+
+After updating composer, add this package's ServiceProvider to the providers array in config/app.php
 
 ServiceProvider:
 ```php
@@ -36,6 +46,8 @@ In order to set the required variables for your instance of IPBoard, you must fi
 ```
 php artisan vendor:publish
 ```
+
+Then, edit your API key and IP.Board URL into config/ipboard.php
 
 ## Usage
 

--- a/src/Console/TestCommand.php
+++ b/src/Console/TestCommand.php
@@ -1,4 +1,6 @@
-<?php namespace Alawrence\Ipboard\Console;
+<?php
+
+namespace Alawrence\Ipboard\Console;
 
 use Alawrence\Ipboard\Ipboard;
 use Illuminate\Console\Command;
@@ -20,15 +22,16 @@ class TestCommand extends Command
     {
         $result = $this->ipboard->hello();
 
-        if(array_get($result, "communityName", null)){
-            $this->info("Your community is online:");
-            $this->info("URL: ".$result["communityUrl"]);
-            $this->info("Name: ".$result["communityName"]);
-            $this->info("Version: ".$result["ipsVersion"]);
+        if (array_get($result, 'communityName', null)) {
+            $this->info('Your community is online:');
+            $this->info('URL: '.$result['communityUrl']);
+            $this->info('Name: '.$result['communityName']);
+            $this->info('Version: '.$result['ipsVersion']);
+
             return;
         }
 
         $this->error("It doesn't look like your community API can be reached.  Check your config file (config/ipboard.php)");
-        $this->error("If you cannot find your config file, ensure you have published all vendor files.");
+        $this->error('If you cannot find your config file, ensure you have published all vendor files.');
     }
 }

--- a/src/Console/TestCommand.php
+++ b/src/Console/TestCommand.php
@@ -16,7 +16,7 @@ class TestCommand extends Command
         $this->ipboard = $ipboard;
     }
 
-    public function fire()
+    public function handle()
     {
         $result = $this->ipboard->hello();
 

--- a/src/Endpoints/Forums/Forums.php
+++ b/src/Endpoints/Forums/Forums.php
@@ -2,9 +2,9 @@
 
 namespace Alawrence\Ipboard;
 
+use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 use Alawrence\Ipboard\Exceptions\IpboardInvalidApiKey;
 use Alawrence\Ipboard\Exceptions\IpboardMemberIdInvalid;
-use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 
 trait Forums
 {

--- a/src/Endpoints/Forums/Forums.php
+++ b/src/Endpoints/Forums/Forums.php
@@ -9,9 +9,8 @@ use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 trait Forums
 {
     /**
-     * Fetch all forums
+     * Fetch all forums.
      *
-     * @return mixed
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
      * @throws Exceptions\IpboardMemberUsernameExists
@@ -19,18 +18,19 @@ trait Forums
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumsAll()
     {
-        return $this->getRequest("forums/forums");
+        return $this->getRequest('forums/forums');
     }
 
     /**
      * Get a specific forum given the ID.
      *
-     * @param integer $forumId The ID of the forum post to retrieve.
+     * @param int $forumId The ID of the forum post to retrieve.
      *
-     * @return mixed
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
      * @throws Exceptions\IpboardMemberUsernameExists
@@ -38,9 +38,11 @@ trait Forums
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumById($forumId)
     {
-        return $this->getRequest("forums/forums/" . $forumId);
+        return $this->getRequest('forums/forums/'.$forumId);
     }
 }

--- a/src/Endpoints/Forums/Posts.php
+++ b/src/Endpoints/Forums/Posts.php
@@ -9,12 +9,11 @@ use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 trait Posts
 {
     /**
-     * Fetch all forum posts that match the given search criteria
+     * Fetch all forum posts that match the given search criteria.
      *
      * @param array $searchCriteria The search criteria posts should match.
-     * @param integer $page The page number to retrieve (default 1).
+     * @param int   $page           The page number to retrieve (default 1).
      *
-     * @return mixed
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
      * @throws Exceptions\IpboardMemberUsernameExists
@@ -23,39 +22,41 @@ trait Posts
      * @throws IpboardThrottled
      * @throws Exceptions\InvalidFormat
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumPostsByPage($searchCriteria, $page = 1)
     {
         $validator = \Validator::make($searchCriteria, [
-            "forums"        => "string|is_csv_numeric",
-            "authors"       => "string|is_csv_numeric",
-            "hasBestAnswer" => "in:1,0",
-            "hasPoll"       => "in:1,0",
-            "locked"        => "in:1,0",
-            "hidden"        => "in:1,0",
-            "pinned"        => "in:1,0",
-            "featured"      => "in:1,0",
-            "archived"      => "in:1,0",
-            "sortBy"        => "in:id,date,title",
-            "sortDir"       => "in:asc,desc",
+            'forums'        => 'string|is_csv_numeric',
+            'authors'       => 'string|is_csv_numeric',
+            'hasBestAnswer' => 'in:1,0',
+            'hasPoll'       => 'in:1,0',
+            'locked'        => 'in:1,0',
+            'hidden'        => 'in:1,0',
+            'pinned'        => 'in:1,0',
+            'featured'      => 'in:1,0',
+            'archived'      => 'in:1,0',
+            'sortBy'        => 'in:id,date,title',
+            'sortDir'       => 'in:asc,desc',
         ], [
-            "is_csv_numeric" => "The :attribute must be a comma separated string of IDs.",
+            'is_csv_numeric' => 'The :attribute must be a comma separated string of IDs.',
         ]);
 
         if ($validator->fails()) {
             $message = head(array_flatten($validator->messages()));
+
             throw new Exceptions\InvalidFormat($message);
         }
 
-        return $this->getRequest("forums/posts", array_merge($searchCriteria, ["page" => $page]));
+        return $this->getRequest('forums/posts', array_merge($searchCriteria, ['page' => $page]));
     }
 
     /**
-     * Fetch all forum posts that match the given search criteria
+     * Fetch all forum posts that match the given search criteria.
      *
      * @param array $searchCriteria The search criteria posts should match.
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -64,6 +65,8 @@ trait Posts
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumPostsAll($searchCriteria)
     {
@@ -82,9 +85,8 @@ trait Posts
     /**
      * Get a specific forum post given the ID.
      *
-     * @param integer $postId The ID of the forum post to retrieve.
+     * @param int $postId The ID of the forum post to retrieve.
      *
-     * @return mixed
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
      * @throws Exceptions\IpboardMemberUsernameExists
@@ -92,21 +94,22 @@ trait Posts
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumPostById($postId)
     {
-        return $this->getRequest("forums/posts/" . $postId);
+        return $this->getRequest('forums/posts/'.$postId);
     }
 
     /**
      * Create a forum post with the given data.
      *
-     * @param integer $topicID  The ID of the topic to add the post to.
-     * @param integer $authorID The ID of the author for the post (if set to 0, author_name is used)
-     * @param string $post      The HTML content of the post.
-     * @param array $extra
+     * @param int    $topicID  The ID of the topic to add the post to.
+     * @param int    $authorID The ID of the author for the post (if set to 0, author_name is used)
+     * @param string $post     The HTML content of the post.
+     * @param array  $extra
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -115,28 +118,31 @@ trait Posts
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function createForumPost($topicID, $authorID, $post, $extra = [])
     {
-        $data = ["topic" => $topicID, "author" => $authorID, "post" => $post];
+        $data = ['topic' => $topicID, 'author' => $authorID, 'post' => $post];
         $data = array_merge($data, $extra);
 
         $validator = \Validator::make($data, [
-            "topic"       => "required|numeric",
-            "author"      => "required|numeric",
-            "post"        => "required|string",
-            "author_name" => "required_if:author,0|string",
-            "date"        => "date_format:YYYY-mm-dd H:i:s",
-            "ip_address"  => "ip",
-            "hidden"      => "in:-1,0,1",
+            'topic'       => 'required|numeric',
+            'author'      => 'required|numeric',
+            'post'        => 'required|string',
+            'author_name' => 'required_if:author,0|string',
+            'date'        => 'date_format:YYYY-mm-dd H:i:s',
+            'ip_address'  => 'ip',
+            'hidden'      => 'in:-1,0,1',
         ]);
 
         if ($validator->fails()) {
             $message = head(array_flatten($validator->messages()));
+
             throw new Exceptions\InvalidFormat($message);
         }
 
-        return $this->postRequest("forums/posts", $data);
+        return $this->postRequest('forums/posts', $data);
     }
 
     /**
@@ -145,7 +151,6 @@ trait Posts
      * @param $postId
      * @param array $data The data to edit.
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -154,30 +159,32 @@ trait Posts
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function updateForumPost($postId, $data = [])
     {
         $validator = \Validator::make($data, [
-            "author"      => "numeric",
-            "author_name" => "required_if:author,0|string",
-            "post"        => "string",
-            "hidden"      => "in:-1,0,1",
+            'author'      => 'numeric',
+            'author_name' => 'required_if:author,0|string',
+            'post'        => 'string',
+            'hidden'      => 'in:-1,0,1',
         ]);
 
         if ($validator->fails()) {
             $message = head(array_flatten($validator->messages()));
+
             throw new Exceptions\InvalidFormat($message);
         }
 
-        return $this->postRequest("forums/posts/" . $postId, $data);
+        return $this->postRequest('forums/posts/'.$postId, $data);
     }
 
     /**
      * Delete a forum post given it's ID.
      *
-     * @param integer $postId The ID of the post to delete.
+     * @param int $postId The ID of the post to delete.
      *
-     * @return mixed
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
      * @throws Exceptions\IpboardMemberUsernameExists
@@ -185,9 +192,11 @@ trait Posts
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function deleteForumPost($postId)
     {
-        return $this->deleteRequest("forums/posts/" . $postId);
+        return $this->deleteRequest('forums/posts/'.$postId);
     }
 }

--- a/src/Endpoints/Forums/Posts.php
+++ b/src/Endpoints/Forums/Posts.php
@@ -2,9 +2,9 @@
 
 namespace Alawrence\Ipboard;
 
+use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 use Alawrence\Ipboard\Exceptions\IpboardInvalidApiKey;
 use Alawrence\Ipboard\Exceptions\IpboardMemberIdInvalid;
-use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 
 trait Posts
 {

--- a/src/Endpoints/Forums/Topics.php
+++ b/src/Endpoints/Forums/Topics.php
@@ -9,12 +9,11 @@ use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 trait Topics
 {
     /**
-     * Fetch all forum topics that match the given search criteria
+     * Fetch all forum topics that match the given search criteria.
      *
      * @param array $searchCriteria The search criteria topics should match.
-     * @param integer $page The page number to retrieve (default 1).
+     * @param int   $page           The page number to retrieve (default 1).
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -23,39 +22,41 @@ trait Topics
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumTopicsByPage($searchCriteria, $page = 1)
     {
         $validator = \Validator::make($searchCriteria, [
-            "forums"        => "string|is_csv_numeric",
-            "authors"       => "string|is_csv_numeric",
-            "hasBestAnswer" => "in:1,0",
-            "hasPoll"       => "in:1,0",
-            "locked"        => "in:1,0",
-            "hidden"        => "in:1,0",
-            "pinned"        => "in:1,0",
-            "featured"      => "in:1,0",
-            "archived"      => "in:1,0",
-            "sortBy"        => "in:id,date,title",
-            "sortDir"       => "in:asc,desc",
+            'forums'        => 'string|is_csv_numeric',
+            'authors'       => 'string|is_csv_numeric',
+            'hasBestAnswer' => 'in:1,0',
+            'hasPoll'       => 'in:1,0',
+            'locked'        => 'in:1,0',
+            'hidden'        => 'in:1,0',
+            'pinned'        => 'in:1,0',
+            'featured'      => 'in:1,0',
+            'archived'      => 'in:1,0',
+            'sortBy'        => 'in:id,date,title',
+            'sortDir'       => 'in:asc,desc',
         ], [
-            "is_csv_numeric" => "The :attribute must be a comma separated string of IDs.",
+            'is_csv_numeric' => 'The :attribute must be a comma separated string of IDs.',
         ]);
 
         if ($validator->fails()) {
             $message = head(array_flatten($validator->messages()));
+
             throw new Exceptions\InvalidFormat($message);
         }
 
-        return $this->getRequest("forums/topics", array_merge($searchCriteria, ["page" => $page]));
+        return $this->getRequest('forums/topics', array_merge($searchCriteria, ['page' => $page]));
     }
 
     /**
-     * Fetch all forum topics that match the given search criteria
+     * Fetch all forum topics that match the given search criteria.
      *
-     * @param integer $searchCriteria The search criteria topics should match.
+     * @param int $searchCriteria The search criteria topics should match.
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -64,6 +65,8 @@ trait Topics
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumTopicsAll($searchCriteria)
     {
@@ -82,9 +85,8 @@ trait Topics
     /**
      * Get a specific forum topic given the ID.
      *
-     * @param integer $topicId The ID of the forum topic to retrieve.
+     * @param int $topicId The ID of the forum topic to retrieve.
      *
-     * @return mixed
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
      * @throws Exceptions\IpboardMemberUsernameExists
@@ -92,20 +94,21 @@ trait Topics
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumTopicById($topicId)
     {
-        return $this->getRequest("forums/topics/" . $topicId);
+        return $this->getRequest('forums/topics/'.$topicId);
     }
 
     /**
      * Get a specific forum topic given the ID.
      *
-     * @param integer $topicId The ID of the forum topic to retrieve.
+     * @param int   $topicId        The ID of the forum topic to retrieve.
      * @param array $searchCriteria The search criteria posts should match.
-     * @param integer $page The page number to retrieve (default 1).
+     * @param int   $page           The page number to retrieve (default 1).
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -114,32 +117,34 @@ trait Topics
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function getForumTopicPosts($topicId, $searchCriteria = [], $page = 1)
     {
         $validator = \Validator::make($searchCriteria, [
-            "hidden"        => "in:1,0",
-            "sortDir"       => "in:asc,desc",
+            'hidden'        => 'in:1,0',
+            'sortDir'       => 'in:asc,desc',
         ]);
 
         if ($validator->fails()) {
             $message = head(array_flatten($validator->messages()));
+
             throw new Exceptions\InvalidFormat($message);
         }
 
-        return $this->getRequest("forums/topics/" . $topicId . "/posts", array_merge($searchCriteria, ["page" => $page]));
+        return $this->getRequest('forums/topics/'.$topicId.'/posts', array_merge($searchCriteria, ['page' => $page]));
     }
 
     /**
      * Create a forum topic with the given data.
      *
      * @param $forumID
-     * @param integer $authorID The ID of the author for the topic (if set to 0, author_name is used)
-     * @param string $title The title of the topic.
-     * @param string $post The HTML content of the post.
-     * @param array $extra
+     * @param int    $authorID The ID of the author for the topic (if set to 0, author_name is used)
+     * @param string $title    The title of the topic.
+     * @param string $post     The HTML content of the post.
+     * @param array  $extra
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -148,47 +153,49 @@ trait Topics
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function createForumTopic($forumID, $authorID, $title, $post, $extra = [])
     {
-        $data = ["forum" => $forumID, "author" => $authorID, "title" => $title, "post" => $post];
+        $data = ['forum' => $forumID, 'author' => $authorID, 'title' => $title, 'post' => $post];
         $data = array_merge($data, $extra);
 
         $validator = \Validator::make($data, [
-            "forum"       => "required|numeric",
-            "author"      => "required|numeric",
-            "title"       => "required|string",
-            "post"        => "required|string",
-            "author_name" => "required_if:author,0|string",
-            "prefix"      => "string",
-            "tags"        => "string|is_csv_alphanumeric",
-            "date"        => "date_format:YYYY-mm-dd H:i:s",
-            "ip_address"  => "ip",
-            "locked"      => "in:0,1",
-            "open_time"   => "date_format:YYYY-mm-dd H:i:s",
-            "close_time"  => "date_format:YYYY-mm-dd H:i:s",
-            "hidden"      => "in:-1,0,1",
-            "pinned"      => "in:0,1",
-            "featured"    => "in:0,1",
+            'forum'       => 'required|numeric',
+            'author'      => 'required|numeric',
+            'title'       => 'required|string',
+            'post'        => 'required|string',
+            'author_name' => 'required_if:author,0|string',
+            'prefix'      => 'string',
+            'tags'        => 'string|is_csv_alphanumeric',
+            'date'        => 'date_format:YYYY-mm-dd H:i:s',
+            'ip_address'  => 'ip',
+            'locked'      => 'in:0,1',
+            'open_time'   => 'date_format:YYYY-mm-dd H:i:s',
+            'close_time'  => 'date_format:YYYY-mm-dd H:i:s',
+            'hidden'      => 'in:-1,0,1',
+            'pinned'      => 'in:0,1',
+            'featured'    => 'in:0,1',
         ], [
-            "is_csv_alphanumeric" => "The :attribute must be a comma separated string.",
+            'is_csv_alphanumeric' => 'The :attribute must be a comma separated string.',
         ]);
 
         if ($validator->fails()) {
             $message = head(array_flatten($validator->messages()));
+
             throw new Exceptions\InvalidFormat($message);
         }
 
-        return $this->postRequest("forums/topics", $data);
+        return $this->postRequest('forums/topics', $data);
     }
 
     /**
      * Update a forum topic with the given ID.
      *
-     * @param integer $topicID The ID of the topic to update.
-     * @param array $data The data to edit.
+     * @param int   $topicID The ID of the topic to update.
+     * @param array $data    The data to edit.
      *
-     * @return mixed
      * @throws Exceptions\InvalidFormat
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
@@ -197,43 +204,45 @@ trait Topics
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function updateForumTopic($topicID, $data = [])
     {
         $validator = \Validator::make($data, [
-            "forum" => "numeric",
-            "author"      => "numeric",
-            "author_name" => "required_if:author,0|string",
-            "title" => "string",
-            "post" => "string",
-            "prefix" => "string",
-            "tags"        => "string|is_csv_alphanumeric",
-            "date"        => "date_format:YYYY-mm-dd H:i:s",
-            "ip_address"  => "ip",
-            "locked"      => "in:0,1",
-            "open_time"   => "date_format:YYYY-mm-dd H:i:s",
-            "close_time"  => "date_format:YYYY-mm-dd H:i:s",
-            "hidden"      => "in:-1,0,1",
-            "pinned"      => "in:0,1",
-            "featured"    => "in:0,1",
+            'forum'       => 'numeric',
+            'author'      => 'numeric',
+            'author_name' => 'required_if:author,0|string',
+            'title'       => 'string',
+            'post'        => 'string',
+            'prefix'      => 'string',
+            'tags'        => 'string|is_csv_alphanumeric',
+            'date'        => 'date_format:YYYY-mm-dd H:i:s',
+            'ip_address'  => 'ip',
+            'locked'      => 'in:0,1',
+            'open_time'   => 'date_format:YYYY-mm-dd H:i:s',
+            'close_time'  => 'date_format:YYYY-mm-dd H:i:s',
+            'hidden'      => 'in:-1,0,1',
+            'pinned'      => 'in:0,1',
+            'featured'    => 'in:0,1',
         ], [
-            "is_csv_alphanumeric" => "The :attribute must be a comma separated string.",
+            'is_csv_alphanumeric' => 'The :attribute must be a comma separated string.',
         ]);
 
         if ($validator->fails()) {
             $message = head(array_flatten($validator->messages()));
+
             throw new Exceptions\InvalidFormat($message);
         }
 
-        return $this->postRequest("forums/topics/" . $topicID, $data);
+        return $this->postRequest('forums/topics/'.$topicID, $data);
     }
 
     /**
      * Delete a forum topic given it's ID.
      *
-     * @param integer $topicId The ID of the topic to delete.
+     * @param int $topicId The ID of the topic to delete.
      *
-     * @return mixed
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberInvalidGroup
      * @throws Exceptions\IpboardMemberUsernameExists
@@ -241,9 +250,11 @@ trait Topics
      * @throws IpboardMemberIdInvalid
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function deleteForumTopic($topicId)
     {
-        return $this->deleteRequest("forums/topics/" . $topicId);
+        return $this->deleteRequest('forums/topics/'.$topicId);
     }
 }

--- a/src/Endpoints/Forums/Topics.php
+++ b/src/Endpoints/Forums/Topics.php
@@ -2,9 +2,9 @@
 
 namespace Alawrence\Ipboard;
 
+use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 use Alawrence\Ipboard\Exceptions\IpboardInvalidApiKey;
 use Alawrence\Ipboard\Exceptions\IpboardMemberIdInvalid;
-use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 
 trait Topics
 {

--- a/src/Endpoints/System/Hello.php
+++ b/src/Endpoints/System/Hello.php
@@ -7,14 +7,14 @@ trait Hello
     /**
      * Call core/hello to find details of forum instance.
      *
-     * @return string json return.
-     *
      * @throws \Alawrence\Ipboard\Exceptions\IpboardInvalidApiKey
      * @throws \Alawrence\Ipboard\Exceptions\IpboardThrottled
      * @throws \Alawrence\Ipboard\Exceptions\IpboardMemberIdInvalid
+     *
+     * @return string json return.
      */
     public function hello()
     {
-        return $this->getRequest("core/hello");
+        return $this->getRequest('core/hello');
     }
 }

--- a/src/Endpoints/System/Members.php
+++ b/src/Endpoints/System/Members.php
@@ -2,12 +2,12 @@
 
 namespace Alawrence\Ipboard;
 
+use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 use Alawrence\Ipboard\Exceptions\IpboardInvalidApiKey;
-use Alawrence\Ipboard\Exceptions\IpboardMemberEmailExists;
 use Alawrence\Ipboard\Exceptions\IpboardMemberIdInvalid;
+use Alawrence\Ipboard\Exceptions\IpboardMemberEmailExists;
 use Alawrence\Ipboard\Exceptions\IpboardMemberInvalidGroup;
 use Alawrence\Ipboard\Exceptions\IpboardMemberUsernameExists;
-use Alawrence\Ipboard\Exceptions\IpboardThrottled;
 
 trait Members
 {

--- a/src/Endpoints/System/Members.php
+++ b/src/Endpoints/System/Members.php
@@ -14,11 +14,10 @@ trait Members
     /**
      * Call to core/members to get a specific page of users.
      *
-     * @param string $sortBy Possible values are joined, name or ID (Default ID)
+     * @param string $sortBy  Possible values are joined, name or ID (Default ID)
      * @param string $sortDir Possible values are 'asc' and 'desc' (Default asc)
-     * @param integer $page Any positive integer, up to the maximum number of pages.
+     * @param int    $page    Any positive integer, up to the maximum number of pages.
      *
-     * @return string json return.
      * @throws IpboardInvalidApiKey
      * @throws IpboardMemberEmailExists
      * @throws IpboardMemberIdInvalid
@@ -26,20 +25,21 @@ trait Members
      * @throws IpboardMemberUsernameExists
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return string json return.
      */
-    public function getMembersByPage($sortBy = "ID", $sortDir = "asc", $page = 1)
+    public function getMembersByPage($sortBy = 'ID', $sortDir = 'asc', $page = 1)
     {
-        return $this->getRequest("core/members",
-            ["query" => ["sortBy" => $sortBy, "sortDir" => $sortDir, "page" => $page]]);
+        return $this->getRequest('core/members',
+            ['query' => ['sortBy' => $sortBy, 'sortDir' => $sortDir, 'page' => $page]]);
     }
 
     /**
      * Call to core/members to get all users in the database.
      *
-     * @param string $sortBy Possible values are joined, name or ID (Default ID)
+     * @param string $sortBy  Possible values are joined, name or ID (Default ID)
      * @param string $sortDir Possible values are 'asc' and 'desc' (Default asc)
      *
-     * @return string json return.
      * @throws IpboardInvalidApiKey
      * @throws IpboardMemberEmailExists
      * @throws IpboardMemberIdInvalid
@@ -47,8 +47,10 @@ trait Members
      * @throws IpboardMemberUsernameExists
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return string json return.
      */
-    public function getMembersAll($sortBy = "ID", $sortDir = "asc")
+    public function getMembersAll($sortBy = 'ID', $sortDir = 'asc')
     {
         $allMembers = [];
 
@@ -65,9 +67,8 @@ trait Members
     /**
      * Get a specific member details by their ID number.
      *
-     * @param integer $memberID The ID number of the member to retrieve details for.
+     * @param int $memberID The ID number of the member to retrieve details for.
      *
-     * @return string
      * @throws IpboardInvalidApiKey
      * @throws IpboardMemberEmailExists
      * @throws IpboardMemberIdInvalid
@@ -75,21 +76,22 @@ trait Members
      * @throws IpboardMemberUsernameExists
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return string
      */
     public function getMemberById($memberID)
     {
-        return $this->getRequest("core/members/" . $memberID);
+        return $this->getRequest('core/members/'.$memberID);
     }
 
     /**
      * Create a new member with the given information.
      *
-     * @param string    $name     The display/username of the member to create.
-     * @param string    $email    The email address to associate with the member.
-     * @param string    $password The password to create the user account with.
-     * @param integer   $group    The primary group to assign to the member (default = null, members)
+     * @param string $name     The display/username of the member to create.
+     * @param string $email    The email address to associate with the member.
+     * @param string $password The password to create the user account with.
+     * @param int    $group    The primary group to assign to the member (default = null, members)
      *
-     * @return mixed
      * @throws IpboardInvalidApiKey
      * @throws IpboardMemberEmailExists
      * @throws IpboardMemberIdInvalid
@@ -97,19 +99,20 @@ trait Members
      * @throws IpboardMemberUsernameExists
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function createMember($name, $email, $password, $group = null)
     {
-        return $this->postRequest("core/members", compact("name", "email", "password", "group"));
+        return $this->postRequest('core/members', compact('name', 'email', 'password', 'group'));
     }
 
     /**
      * Update an existing member with the details provided.
      *
-     * @param integer $memberID The member ID of the member to update.
-     * @param array $data Array of data (Allowed keys are name, email and password).
+     * @param int   $memberID The member ID of the member to update.
+     * @param array $data     Array of data (Allowed keys are name, email and password).
      *
-     * @return mixed
      * @throws IpboardInvalidApiKey
      * @throws IpboardThrottled
      * @throws IpboardMemberIdInvalid
@@ -117,18 +120,19 @@ trait Members
      * @throws IpboardMemberUsernameExists
      * @throws IpboardMemberEmailExists
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function updateMember($memberID, array $data = [])
     {
-        return $this->postRequest("core/members/" . $memberID, $data);
+        return $this->postRequest('core/members/'.$memberID, $data);
     }
 
     /**
      * Delete a member with the given ID.
      *
-     * @param integer $memberID The member ID of the member to delete.
+     * @param int $memberID The member ID of the member to delete.
      *
-     * @return mixed
      * @throws IpboardInvalidApiKey
      * @throws IpboardMemberEmailExists
      * @throws IpboardMemberIdInvalid
@@ -136,9 +140,11 @@ trait Members
      * @throws IpboardMemberUsernameExists
      * @throws IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     public function deleteMemberById($memberID)
     {
-        return $this->deleteRequest("core/members/" . $memberID);
+        return $this->deleteRequest('core/members/'.$memberID);
     }
 }

--- a/src/Exceptions/InvalidFormat.php
+++ b/src/Exceptions/InvalidFormat.php
@@ -1,5 +1,7 @@
-<?php namespace Alawrence\Ipboard\Exceptions;
+<?php
 
-class InvalidFormat extends \Exception {
+namespace Alawrence\Ipboard\Exceptions;
 
+class InvalidFormat extends \Exception
+{
 }

--- a/src/Exceptions/IpboardCannotAuthorFirstPost.php
+++ b/src/Exceptions/IpboardCannotAuthorFirstPost.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 22:55
+ * Time: 22:55.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardCannotAuthorFirstPost extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardCannotDeleteFirstPost.php
+++ b/src/Exceptions/IpboardCannotDeleteFirstPost.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 22:58
+ * Time: 22:58.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardCannotDeleteFirstPost extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardCannotHideFirstPost.php
+++ b/src/Exceptions/IpboardCannotHideFirstPost.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 22:54
+ * Time: 22:54.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardCannotHideFirstPost extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardForumIdInvalid.php
+++ b/src/Exceptions/IpboardForumIdInvalid.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 23:04
+ * Time: 23:04.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardForumIdInvalid extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardForumPostIdInvalid.php
+++ b/src/Exceptions/IpboardForumPostIdInvalid.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 21:36
+ * Time: 21:36.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardForumPostIdInvalid extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardForumTopicIdInvalid.php
+++ b/src/Exceptions/IpboardForumTopicIdInvalid.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 22:51
+ * Time: 22:51.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardForumTopicIdInvalid extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardInvalidApiKey.php
+++ b/src/Exceptions/IpboardInvalidApiKey.php
@@ -1,6 +1,8 @@
-<?php namespace Alawrence\Ipboard\Exceptions;
+<?php
+
+namespace Alawrence\Ipboard\Exceptions;
 
 // Error 3S290/7
-class IpboardInvalidApiKey extends \Exception {
-
+class IpboardInvalidApiKey extends \Exception
+{
 }

--- a/src/Exceptions/IpboardMemberEmailExists.php
+++ b/src/Exceptions/IpboardMemberEmailExists.php
@@ -1,6 +1,7 @@
-<?php namespace Alawrence\Ipboard\Exceptions;
+<?php
+
+namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardMemberEmailExists extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardMemberIdInvalid.php
+++ b/src/Exceptions/IpboardMemberIdInvalid.php
@@ -1,7 +1,8 @@
-<?php namespace Alawrence\Ipboard\Exceptions;
+<?php
 
+namespace Alawrence\Ipboard\Exceptions;
 
 // Error 1C292/2
-class IpboardMemberIdInvalid extends \Exception {
-
+class IpboardMemberIdInvalid extends \Exception
+{
 }

--- a/src/Exceptions/IpboardMemberInvalidGroup.php
+++ b/src/Exceptions/IpboardMemberInvalidGroup.php
@@ -1,6 +1,7 @@
-<?php namespace Alawrence\Ipboard\Exceptions;
+<?php
+
+namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardMemberInvalidGroup extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardMemberUsernameExists.php
+++ b/src/Exceptions/IpboardMemberUsernameExists.php
@@ -1,6 +1,7 @@
-<?php namespace Alawrence\Ipboard\Exceptions;
+<?php
+
+namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardMemberUsernameExists extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardPostInvalid.php
+++ b/src/Exceptions/IpboardPostInvalid.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 22:51
+ * Time: 22:51.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardPostInvalid extends \Exception
 {
-
 }

--- a/src/Exceptions/IpboardThrottled.php
+++ b/src/Exceptions/IpboardThrottled.php
@@ -1,5 +1,7 @@
-<?php namespace Alawrence\Ipboard\Exceptions;
+<?php
 
-class IpboardThrottled extends \Exception {
+namespace Alawrence\Ipboard\Exceptions;
 
+class IpboardThrottled extends \Exception
+{
 }

--- a/src/Exceptions/IpboardTopicTitleInvalid.php
+++ b/src/Exceptions/IpboardTopicTitleInvalid.php
@@ -3,12 +3,11 @@
  * Created by PhpStorm.
  * User: Anthony
  * Date: 05/01/2016
- * Time: 23:05
+ * Time: 23:05.
  */
 
 namespace Alawrence\Ipboard\Exceptions;
 
 class IpboardTopicTitleInvalid extends \Exception
 {
-
 }

--- a/src/Facades/Ipboard.php
+++ b/src/Facades/Ipboard.php
@@ -1,13 +1,18 @@
-<?php namespace Alawrence\Ipboard\Facades;
+<?php
+
+namespace Alawrence\Ipboard\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class Ipboard extends Facade {
-
-	/**
-	 * Get the registered name of the component.
-	 *
-	 * @return string
-	 */
-	protected static function getFacadeAccessor() { return 'ipboard'; }
+class Ipboard extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'ipboard';
+    }
 }

--- a/src/Ipboard.php
+++ b/src/Ipboard.php
@@ -3,9 +3,9 @@
 namespace Alawrence\Ipboard;
 
 use GuzzleHttp\Client as HttpClient;
-use GuzzleHttp\Exception\ClientException;
 use Mockery\CountValidator\Exception;
 use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Exception\ClientException;
 
 class Ipboard
 {

--- a/src/Ipboard.php
+++ b/src/Ipboard.php
@@ -1,4 +1,6 @@
-<?php namespace Alawrence\Ipboard;
+<?php
+
+namespace Alawrence\Ipboard;
 
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
@@ -23,33 +25,33 @@ class Ipboard
         // General/Unknown
         520       => \Exception::class,
         // Authorization.
-        "3S290/7" => Exceptions\IpboardInvalidApiKey::class,
+        '3S290/7' => Exceptions\IpboardInvalidApiKey::class,
         401       => Exceptions\IpboardInvalidApiKey::class,
         429       => Exceptions\IpboardThrottled::class,
         // Core/member
-        "1C292/2" => Exceptions\IpboardMemberIdInvalid::class,
-        "1C292/3" => Exceptions\IpboardMemberIdInvalid::class,
-        "1C292/4" => Exceptions\IpboardMemberUsernameExists::class,
-        "1C292/5" => Exceptions\IpboardMemberEmailExists::class,
-        "1C292/6" => Exceptions\IpboardMemberInvalidGroup::class,
-        "1C292/7" => Exceptions\IpboardMemberIdInvalid::class,
+        '1C292/2' => Exceptions\IpboardMemberIdInvalid::class,
+        '1C292/3' => Exceptions\IpboardMemberIdInvalid::class,
+        '1C292/4' => Exceptions\IpboardMemberUsernameExists::class,
+        '1C292/5' => Exceptions\IpboardMemberEmailExists::class,
+        '1C292/6' => Exceptions\IpboardMemberInvalidGroup::class,
+        '1C292/7' => Exceptions\IpboardMemberIdInvalid::class,
         // forums/posts
-        "1F295/1" => Exceptions\IpboardForumTopicIdInvalid::class,
-        "1F295/2" => Exceptions\IpboardMemberIdInvalid::class,
-        "1F295/3" => Exceptions\IpboardPostInvalid::class,
-        "1F295/4" => Exceptions\IpboardForumPostIdInvalid::class,
-        "1F295/5" => Exceptions\IpboardForumPostIdInvalid::class,
-        "2F295/6" => Exceptions\IpboardForumPostIdInvalid::class,
-        "2F295/7" => Exceptions\IpboardMemberIdInvalid::class,
-        "1F295/8" => Exceptions\IpboardCannotHideFirstPost::class,
-        "1F295/9" => Exceptions\IpboardCannotAuthorFirstPost::class,
-        "1F295/B" => Exceptions\IpboardCannotDeleteFirstPost::class,
+        '1F295/1' => Exceptions\IpboardForumTopicIdInvalid::class,
+        '1F295/2' => Exceptions\IpboardMemberIdInvalid::class,
+        '1F295/3' => Exceptions\IpboardPostInvalid::class,
+        '1F295/4' => Exceptions\IpboardForumPostIdInvalid::class,
+        '1F295/5' => Exceptions\IpboardForumPostIdInvalid::class,
+        '2F295/6' => Exceptions\IpboardForumPostIdInvalid::class,
+        '2F295/7' => Exceptions\IpboardMemberIdInvalid::class,
+        '1F295/8' => Exceptions\IpboardCannotHideFirstPost::class,
+        '1F295/9' => Exceptions\IpboardCannotAuthorFirstPost::class,
+        '1F295/B' => Exceptions\IpboardCannotDeleteFirstPost::class,
         // torums/topics
-        "1F294/1" => Exceptions\IpboardForumTopicIdInvalid::class,
-        "1F294/2" => Exceptions\IpboardForumIdInvalid::class,
-        "1F294/3" => Exceptions\IpboardMemberIdInvalid::class,
-        "1F294/4" => Exceptions\IpboardPostInvalid::class,
-        "1F294/5" => Exceptions\IpboardTopicTitleInvalid::class,
+        '1F294/1' => Exceptions\IpboardForumTopicIdInvalid::class,
+        '1F294/2' => Exceptions\IpboardForumIdInvalid::class,
+        '1F294/3' => Exceptions\IpboardMemberIdInvalid::class,
+        '1F294/4' => Exceptions\IpboardPostInvalid::class,
+        '1F294/5' => Exceptions\IpboardTopicTitleInvalid::class,
     ];
 
     /**
@@ -59,17 +61,17 @@ class Ipboard
      */
     public function __construct()
     {
-        $this->url = config("ipboard.api_url");
-        $this->key = config("ipboard.api_key");
-        $this->reference = config("ipboard.api_reference_name");
+        $this->url = config('ipboard.api_url');
+        $this->key = config('ipboard.api_key');
+        $this->reference = config('ipboard.api_reference_name');
 
         $this->httpRequest = new HttpClient([
-            "base_uri" => $this->url,
-            "timeout"  => 2.0,
-            "defaults" => [
-                "auth" => [$this->key, ""],
+            'base_uri' => $this->url,
+            'timeout'  => 2.0,
+            'defaults' => [
+                'auth' => [$this->key, ''],
             ],
-            "auth"     => [$this->key, ""],
+            'auth'     => [$this->key, ''],
         ]);
     }
 
@@ -77,9 +79,8 @@ class Ipboard
      * Perform a get request.
      *
      * @param string $function The endpoint to call via GET.
-     * @param array $extra Any query string parameters.
+     * @param array  $extra    Any query string parameters.
      *
-     * @return string json return.
      * @throws Exceptions\IpboardInvalidApiKey
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberIdInvalid
@@ -87,19 +88,20 @@ class Ipboard
      * @throws Exceptions\IpboardMemberUsernameExists
      * @throws Exceptions\IpboardThrottled
      * @throws \Exception
+     *
+     * @return string json return.
      */
     private function getRequest($function, $extra = [])
     {
-        return $this->request("GET", $function, ["query" => $extra]);
+        return $this->request('GET', $function, ['query' => $extra]);
     }
 
     /**
      * Perform a post request.
      *
      * @param string $function The endpoint to perform a POST request on.
-     * @param array $data The form data to be sent.
+     * @param array  $data     The form data to be sent.
      *
-     * @return mixed
      * @throws Exceptions\IpboardInvalidApiKey
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberIdInvalid
@@ -107,10 +109,12 @@ class Ipboard
      * @throws Exceptions\IpboardMemberUsernameExists
      * @throws Exceptions\IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     private function postRequest($function, $data)
     {
-        return $this->request("POST", $function, ["form_params" => $data]);
+        return $this->request('POST', $function, ['form_params' => $data]);
     }
 
     /**
@@ -118,7 +122,6 @@ class Ipboard
      *
      * @param string $function The endpoint to perform a DELETE request on.
      *
-     * @return mixed
      * @throws Exceptions\IpboardInvalidApiKey
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberIdInvalid
@@ -126,20 +129,21 @@ class Ipboard
      * @throws Exceptions\IpboardMemberUsernameExists
      * @throws Exceptions\IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     private function deleteRequest($function)
     {
-        return $this->request("DELETE", $function);
+        return $this->request('DELETE', $function);
     }
 
     /**
      * Perform the specified request.
      *
-     * @param string $method Either GET, POST, PUT, DELETE, PATCH
+     * @param string $method   Either GET, POST, PUT, DELETE, PATCH
      * @param string $function The endpoint to call.
-     * @param array $extra Any query string information.
+     * @param array  $extra    Any query string information.
      *
-     * @return mixed
      * @throws Exceptions\IpboardInvalidApiKey
      * @throws Exceptions\IpboardMemberEmailExists
      * @throws Exceptions\IpboardMemberIdInvalid
@@ -147,10 +151,13 @@ class Ipboard
      * @throws Exceptions\IpboardMemberUsernameExists
      * @throws Exceptions\IpboardThrottled
      * @throws \Exception
+     *
+     * @return mixed
      */
     private function request($method, $function, $extra = [])
     {
         $response = null;
+
         try {
             $response = $this->httpRequest->{$method}($function, $extra)->getBody();
 
@@ -182,14 +189,12 @@ class Ipboard
 
         try {
             if (array_key_exists($errorCode, $this->error_exceptions)) {
-                throw new $this->error_exceptions[$errorCode];
+                throw new $this->error_exceptions[$errorCode]();
             }
 
-            throw new $this->error_exceptions[$response->getStatusCode()];
+            throw new $this->error_exceptions[$response->getStatusCode()]();
         } catch (Exception $e) {
-            throw new \Exception("There was a malformed response from IPBoard.");
+            throw new \Exception('There was a malformed response from IPBoard.');
         }
     }
-
 }
-

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,11 +22,11 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->mergeConfigFrom($this->getConfigPath(), 'ipboard');
 
-        $this->app['ipboard'] = $this->app->share(function($app){
+        $this->app->singleton('ipboard', function($app){
             return new Ipboard();
         });
 
-        $this->app['command.ipboard.test'] = $this->app->share(
+        $this->app->singleton('command.ipboard.test', 
             function ($app) {
                 return new Console\TestCommand($app['ipboard']);
             }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace Alawrence\Ipboard;
+<?php
+
+namespace Alawrence\Ipboard;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -9,8 +11,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     protected $defer = false;
 
-    private function getConfigPath(){
-        return __DIR__ . '/../config/ipboard.php';
+    private function getConfigPath()
+    {
+        return __DIR__.'/../config/ipboard.php';
     }
 
     /**
@@ -22,17 +25,17 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->mergeConfigFrom($this->getConfigPath(), 'ipboard');
 
-        $this->app->singleton('ipboard', function($app){
+        $this->app->singleton('ipboard', function ($app) {
             return new Ipboard();
         });
 
-        $this->app->singleton('command.ipboard.test', 
+        $this->app->singleton('command.ipboard.test',
             function ($app) {
                 return new Console\TestCommand($app['ipboard']);
             }
         );
 
-        $this->commands(array('command.ipboard.test'));
+        $this->commands(['command.ipboard.test']);
     }
 
     /**
@@ -46,16 +49,16 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             $this->getConfigPath() => config_path('ipboard.php'),
         ]);
 
-        \Validator::extend("is_csv_numeric", function($attribute, $value, $parameters, $validator){
-            return preg_match("/^[0-9,]+$/i", $value);
+        \Validator::extend('is_csv_numeric', function ($attribute, $value, $parameters, $validator) {
+            return preg_match('/^[0-9,]+$/i', $value);
         });
 
-        \Validator::extend("is_csv_alpha", function($attribute, $value, $parameters, $validator){
-            return preg_match("/^[A-Z,]+$/i", $value);
+        \Validator::extend('is_csv_alpha', function ($attribute, $value, $parameters, $validator) {
+            return preg_match('/^[A-Z,]+$/i', $value);
         });
 
-        \Validator::extend("is_csv_alphanumeric", function($attribute, $value, $parameters, $validator){
-            return preg_match("/^[0-9A-Z,]+$/i", $value);
+        \Validator::extend('is_csv_alphanumeric', function ($attribute, $value, $parameters, $validator) {
+            return preg_match('/^[0-9A-Z,]+$/i', $value);
         });
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
-function is_comma_separated_string($string){
-    return preg_match("/^[0-9,]+$/i", $string);
+function is_comma_separated_string($string)
+{
+    return preg_match('/^[0-9,]+$/i', $string);
 }


### PR DESCRIPTION
Bugfixes that allow the project to work on Laravel versions up to current.

Fixing src/Console/TestCommand.php to use the updated "handle"
function to run an artisan command (previous function was fire,
which seems to be documented as outdated as of Laravel 5.1 and
removed in Laravel 5.5)

Fixing src/ServiceProvider.php to use singleton() instead of
share() -- share is removed in Laravel 5.4

Fixing composer.json to add autoloading support, making the
config/app.php file edits no longer required.

Fixing readme.md to reference the support for more recent Laravel
versions as well as the new autoload support for versions 5.5 and
greater

Signed-off-by: bddarwin <bddarwin@gmail.com>