### PR TITLE
Laravel 5.4 Compatibility

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,12 +22,11 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->mergeConfigFrom($this->getConfigPath(), 'ipboard');
 
-        $this->app['ipboard'] = $this->app->share(function($app){
+        $this->app->singleton('ipboard', function($app){
             return new Ipboard();
         });
 
-        $this->app['command.ipboard.test'] = $this->app->share(
-            function ($app) {
+        $this->app->singleton('command.ipboard.test', function ($app) {
                 return new Console\TestCommand($app['ipboard']);
             }
         );


### PR DESCRIPTION
Have been using this forked version (https://github.com/VATSIM-UK/laravel-ipboard) for some time on our Laravel 6 app (https://github.com/VATSIM-UK/core) without any issues. 